### PR TITLE
Fix: Invalid instructions accepted after Python 3 support update

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>pyz80</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+
+python:
+ 
+  - "3.7"
+  
+script:
+
+  - cd testing
+  - ant test-valid -Dpython=python

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: java
 
 python:
  
-  - "3.7"
+  - "2.7"
+  - "3.6"
   
 script:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 
 python:
  
-  - "2.7"
   - "3.6"
   
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ script:
 
   - cd testing
   - ant test-valid -Dpython=python
+  - ant test-invalid -Dpython=python
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
-language: java
+language: python
 
 python:
  
+  - "2.7"
   - "3.6"
   
 script:

--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ This option allows you to save the generated code as a raw binary file, instead 
 
 You may only assemble a single input Z80 source file if you use this option.
 
-`-D symbol`
-`-D symbol=value`
+```
+-D symbol
+-D symbol=value
+```
 
 This option defines a symbol before beginning to assemble the source file. The value of the symbol will be available to all expressions, both within instructions and also in assembler directives.
 
@@ -183,8 +185,10 @@ ld a, defined(DEBUG)
 
 Specify the origin of the code, i.e. the address from which it is intended to be run. This can be anywhere in the address range of the Z80, that is, 0 to 65535.
 
-`DUMP address`
-`DUMP page, offset`
+```
+DUMP address
+DUMP page, offset
+```
 
 Specify the destination address of the code output. This directive is available in two forms. The first takes an address from 16384 to 65535, these are addresses in pages 0 to 2 as addressed in BASIC. The second form takes a page number from 0 to 31, and an offset within that page of 0 to 16383.
 
@@ -194,23 +198,31 @@ The current DUMP address will be marked as the execute address in the directory 
 
 This directive may not be used more than once during assembly.
 
-`DEFB  n [,n ...]`
-`DB    n [,n ...]`
+```
+DEFB  n [,n ...]
+DB    n [,n ...]
+```
 
 Define bytes at the current address. Either DEFB or DB are allowed and are equivalent in meaning. n can be a literal number or any expression, in the range 0 to 255 (or -128 to +127).
 
-`DEFW  n [,n ...]`
-`DW    n [,n ...]`
+```
+DEFW  n [,n ...]
+DW    n [,n ...]
+```
 
 Define words at the current address. Either DEFW or DW are allowed and are equivalent in meaning. n can be a literal number or any expression, in the range 0 to 65535 (or -32768 to +32767).
 
-`DEFM  "string"`
-`DM    "string"`
+```
+DEFM  "string"
+DM    "string"
+```
 
 Define a message at the current address. The string is always delimited by double quotes. To include a double quote in the string itself, place two double quote characters adjacent to each other.
 
-`DEFS  n`
-`DS    n`
+```
+DEFS  n
+DS    n
+```
 
 Define storage space at the current address. The current address increases by n bytes, thus leaving them available for your program's own use.
 
@@ -222,8 +234,10 @@ This ensures that the following instruction will be aligned on the boundary spec
 
 This directive merges a data file from the host filesystem into the object code at the current address. filename is enclosed in double-quotes and is expressed relatively to the file currently being assembled.
 
-`INC "filename"`
-`INCLUDE "filename"`
+```
+INC "filename"
+INCLUDE "filename"
+```
 
 This directive assembles the specified source file starting at the current address, as though the whole file were literally included in the current one. All symbols in the included file will be available globally, and must therefore be unique (unless they are local symbols).
 
@@ -235,9 +249,11 @@ Repeats a single instruction (or directive) range times.
 
 During assembly of this instruction, a symbol FOR is valid and holds the iteration number from 0 to range-1.
 
-`symbol: EQU FOR range`
-`        ...`
-`NEXT symbol`
+```
+symbol: EQU FOR range
+        ...
+NEXT symbol
+```
 
 Repeats several lines of assembly, range times. When the lines between EQU FOR and NEXT are being assembled,  the symbol symbol is valid, and holds the iteration number from 0 to range-1.
 
@@ -245,13 +261,15 @@ FOR...NEXT blocks can be nested, with each layer using a different symbol name.
 
 Where a local symbol is defined within a FOR...NEXT block, it can only be used within the same block. All references to it will target the same iteration.
 
-`IF expression`
-`        ...`
-`[ELSE IF expression]`
-`        ...`
-`[ELSE]`
-`        ...`
-`ENDIF`
+```
+IF expression
+        ...
+[ELSE IF expression]
+        ...
+[ELSE]
+        ...
+ENDIF
+```
 
 An IF block allows conditional assembly of your source based on some condition. For example, you may want to introduce some features during development of an application but to leave them out of release builds; in this case, IF blocks can be effectively used in conjunction with the -D command line option.
 
@@ -302,8 +320,10 @@ DEFB random()\*256
 
 Returns a random integer in the range start ≤ x < stop
 
-`sin(angle)`
-`cos(angle)`
+```
+sin(angle)
+cos(angle)
+```
 
 angle is specified in radians.
 
@@ -319,19 +339,19 @@ Thanks to Simon Owen and other users for their feedback during development.
 
 pyz80 web page:
 
-        [http://www.intensity.org.uk/samcoupe/pyz80.html](http://www.intensity.org.uk/samcoupe/pyz80.html)
+[http://www.intensity.org.uk/samcoupe/pyz80.html](http://www.intensity.org.uk/samcoupe/pyz80.html)
 
 SimCoupe Homepage:
 
-        [http://www.simcoupe.org/](http://www.simcoupe.org/)
+[http://www.simcoupe.org/](http://www.simcoupe.org/)
 
 World of Sam archive:
 
-        [http://www.worldofsam.org/](http://www.worldofsam.org/)
+[http://www.worldofsam.org/](http://www.worldofsam.org/)
 
 Wikipedia entry for the SAM Coupé (and for more links):
 
-        [http://wikipedia.org/wiki/Sam\_Coupe](http://wikipedia.org/wiki/Sam_Coupe)
+[http://wikipedia.org/wiki/Sam\_Coupe](http://wikipedia.org/wiki/Sam_Coupe)
 
 **Disclaimer**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # pyz80 - a Z80 cross assembler
 Unofficial branch of http://sourceforge.net/projects/pyz80/ for fixes and enhancements.
 
+[![Build Status](https://travis-ci.org/stefandrissen/pyz80.svg?branch=master)](https://travis-ci.org/stefandrissen/pyz80)
+
 **pyz80 - a Z80 cross assembler**
 
 Version 1.21, released 11 July 2013

--- a/pyz80.py
+++ b/pyz80.py
@@ -1222,7 +1222,7 @@ def op_add_type(p,opargs,rinstr,ninstr,rrinstr,step_per_register=1,step_per_pair
         if (len(rrinstr) > 1) and pre:
             fatal ("Can't use index registers in this instruction")
         
-        if (len(args) != 2) or (rr1 != 2):
+        if (len(args) != 2) or (rr1 != 2) or (rr2 == -1):
             fatal("Invalid argument")
         
         instr = pre
@@ -1247,6 +1247,8 @@ def op_bit_type(p,opargs,offset):
     if b>7 or b<0:
         fatal ("argument out of range")
     pre,r,post = single(arg2,allow_half=0)
+    if r==-1:
+    	fatal ("Invalid argument")
     instr = pre
     instr.append(0xcb)
     instr.extend(post)

--- a/testing/build.xml
+++ b/testing/build.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="pyz80">
+
+	<property name="python" location="d:/sam/python36/python.exe" />
+
+	<target name="test-valid">
+
+		<exec executable="${python}" failonerror="true">
+			<arg value="../pyz80.py" />
+			<arg value="--obj=_test_.bin" />
+			<arg value="valid.z80s" />
+		</exec>
+
+		<fail message="assembled output does not match reference output">
+			<condition>
+				<not>
+					<filesmatch file1="_test_.bin" file2="valid.bin" />
+				</not>
+			</condition>
+		</fail>
+		
+		<delete file="_test_.bin"/>
+
+	</target>
+
+	<target name="test-invalid">
+
+		<exec executable="${python}" failonerror="true">
+			<arg value="../pyz80.py" />
+			<arg value="-e" />
+			<arg value="invalid.z80s" />
+		</exec>
+
+	</target>
+
+</project>

--- a/testing/build.xml
+++ b/testing/build.xml
@@ -26,9 +26,7 @@
 	<target name="test-invalid">
 
 		<exec executable="${python}" failonerror="true">
-			<arg value="../pyz80.py" />
-			<arg value="-e" />
-			<arg value="invalid.z80s" />
+			<arg value="test_invalid.py" />
 		</exec>
 
 	</target>

--- a/testing/test_invalid.py
+++ b/testing/test_invalid.py
@@ -7,17 +7,19 @@ import binascii
 exitcode = 0
 equ = '\n'.join( [ "nn: equ &1122", "n: equ &33", "o: equ &44", "", "" ] )
 
+FNULL = open( os.devnull, "w" )
+
 file = open( "invalid.z80s", "r" )
 for line in file:
 
 	if line.strip() and not re.match( ".*;.*", line ):
 			
-		print( "assembling", line )
+		# print( "assembling", line )
 		asm = open( "_test_.asm", "w" )
 		asm.write( equ )
 		asm.write( line )
 		asm.close()
-		subprocess.call( [ "python", "../pyz80.py", "--obj=_test_.bin", "_test_.asm" ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL )
+		subprocess.call( [ "python", "../pyz80.py", "--obj=_test_.bin", "_test_.asm" ], stdout=FNULL, stderr=subprocess.STDOUT )
 		
 		if os.path.isfile( "_test_.bin" ):
 		

--- a/testing/test_invalid.py
+++ b/testing/test_invalid.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+import re
+import sys
+import binascii
+
+exitcode = 0
+equ = '\n'.join( [ "nn: equ &1122", "n: equ &33", "o: equ &44", "", "" ] )
+
+file = open( "invalid.z80s", "r" )
+for line in file:
+
+	if line.strip() and not re.match( ".*;.*", line ):
+			
+		print( "assembling", line )
+		asm = open( "_test_.asm", "w" )
+		asm.write( equ )
+		asm.write( line )
+		asm.close()
+		subprocess.call( [ "python", "../pyz80.py", "--obj=_test_.bin", "_test_.asm" ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL )
+		
+		if os.path.isfile( "_test_.bin" ):
+		
+			exitcode = 1
+			with open("_test_.bin", 'rb') as f:
+				content = f.read()			
+			print( "BUG:", line.strip(), "assembles to", binascii.hexlify( content ) )
+			os.remove( "_test_.bin" )			
+		
+if os.path.isfile( "_test_.asm" ):
+	os.remove( "_test_.asm" )
+file.close()	
+
+sys.exit( exitcode )


### PR DESCRIPTION
fixes #8 

Ultimately a check on r being -1 was only needed at two spots.
