### PR TITLE
Prevent error throwing disk full error

### DIFF
--- a/pyz80.py
+++ b/pyz80.py
@@ -97,7 +97,10 @@ def dsk_at(track,side,sector):
 
 
 def add_file_to_disk_image(image, filename, codestartpage, codestartoffset, execpage=0, execoffset=0, filelength=None, fromfile=None ):
-    global firstpageoffset
+    global firstpageoffset, global_currentfile, global_currentline
+
+    global_currentfile = 'add file'
+    global_currentline = ''
 
     if fromfile != None:
         modified = datetime.datetime.fromtimestamp(os.path.getmtime(fromfile))


### PR DESCRIPTION
When the target SAM disk image is full, pyz80 tries to report an error, but reporting the error drowns in its own errors:
````
     [exec] Traceback (most recent call last):
     [exec]   File "C:\Users\stefan\git\pyz80\pyz80.py", line 1888, in <module>
     [exec]     save_file_to_image(image,pathname)
     [exec]   File "C:\Users\stefan\git\pyz80\pyz80.py", line 307, in save_file_to_image
     [exec]     add_file_to_disk_image(image,sam_filename, 1, 0, fromfile=pathname)
     [exec]   File "C:\Users\stefan\git\pyz80\pyz80.py", line 250, in add_file_to_disk_image
     [exec]     fatal("Disk full writing "+filename)
     [exec]   File "C:\Users\stefan\git\pyz80\pyz80.py", line 339, in fatal
     [exec]     print(global_currentfile, 'error:', message)
     [exec] NameError: name 'global_currentfile' is not defined
````
With both globals defined and set, the error is now reported nicely as:
````
     [exec] add file error: Disk full writing oneway.mod
````