### PR TITLE
Erase file timestamp information when comparing against golden.dsk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ test: testing/test.z80s testing/include.z80s
 	./pyz80.py -o test.dsk.gz -s . testing/test.z80s
 	cp testing/golden.dsk.gz golden.dsk.gz
 	gunzip -f test.dsk.gz golden.dsk.gz
+	cat /dev/zero | dd conv=notrunc of=test.dsk bs=1 seek=245 count=5 # test.o file timestamp non-deterministic
 	cmp test.dsk golden.dsk
 	@echo --== TESTING COMPLETED OK ==--
 


### PR DESCRIPTION
The generated test.dsk disk image contains a timestamp from when the file was added to the disk image.

There is a test that compares the test disk image to a static golden image in the `testing` directory.

This was failing, since the golden image did not contain the timestamp information for the `test    .O` file.

This patch wipes the timestamp information before comparing the files.