### PR TITLE
fix nsector calculation

### DIFF
--- a/pyz80.py
+++ b/pyz80.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 from __future__ import division
+import math
 
 # TODO: define and assemble macro blocks
 # added FILESIZE("filename")
@@ -135,7 +136,7 @@ def add_file_to_disk_image(image, filename, codestartpage, codestartoffset, exec
     for i in range(10):
         image[dirpos+1+i]  = ord((filename+"          ")[i])
 
-    nsectors = 1 + (filelength+9)//510
+    nsectors = math.ceil(( filelength + 9 ) / 510)
     image[dirpos+11] = nsectors // 256 # MSB number of sectors used
     image[dirpos+12] = nsectors % 256 # LSB number of sectors used
 


### PR DESCRIPTION
This is a minor optimisation. The calculation for the number of sectors required to store a file overestimated the number of sectors required by one when the filelength+9 was exactly a multiple of 510.

The previous calculation was:
```py
nsectors = 1 + (filelength+9)//510
```
when considering, e.g. a file length of 501 bytes, the total storage needed is 510 bytes, which requires only one sector. However, with this calculation, `nsectors` would be `1 + (501+9)//510 = 1+ 510//510 = 2`.

I've changed the calculation to
```py
nsectors = (filelength+9+509)//510
```
which gives in the same example, `(501+9+509)//510 = (510+509)//510 = 1`, and as soon as one byte of storage is added, it would roll over to 2 sectors, e.g. `(502+9+509)//510 = (511+509)//510 = (510+510)//510 = 2`.

In other words, in the rare case that the filelength+9 is a multiple of 510 bytes, it will save one sector.