### PR TITLE
Structure symbol fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,11 @@ INFORMATION PROVIDED BY THE PROGRAM AND THE DOCUMENTATION.
 
 ## Release History
 
+Version 1.3.1, 27 August 2025
+
+  - Fixed issue where symbols were being defined for elemnts within a struct without
+    the structure prefix
+
 Version 1.3.0, 25 July 2025
 
   - Converted to Python package installed via pip, to simplify use.

--- a/src/pyz80/pyz80.py
+++ b/src/pyz80/pyz80.py
@@ -2092,7 +2092,7 @@ def do_pass(p, wholefile, this_currentfilename):
         if len(symbol.split()) > 1:
             fatal("Whitespace not allowed in symbol name")
 
-        if symbol and (opcode[0:3].upper() !="EQU") and (ifstate < 2) and (macrostate == 0):
+        if (symbol and (opcode[0:3].upper() !="EQU") and (opcode[0:6].upper() !="STRUCT") and (opcode[0:5].upper() !="MACRO") and (ifstate < 2) and (macrostate == 0) and structstate == 0 ):
             if p==1:
                 set_symbol(symbol, origin, is_label=True)
             elif get_symbol(symbol) != origin:


### PR DESCRIPTION
Fixed issue with structures defining symbols without prefix as well meaning two structures could not contain the same name element